### PR TITLE
Express manualChunks as a function so the Vite 8 build works

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -30,10 +30,21 @@ export default defineConfig({
     sourcemap: true,
     rollupOptions: {
       output: {
-        manualChunks: {
-          vendor: ['react', 'react-dom'],
-          router: ['react-router-dom'],
-          query: ['@tanstack/react-query'],
+        // Function form, not the object form. Vite 8 builds with rolldown,
+        // which accepts only a function here and fails the build outright with
+        // "TypeError: manualChunks is not a function". Rollup accepts both, so
+        // this form is correct before and after that upgrade.
+        //
+        // Order is load-bearing: the tests run longest-prefix first, because
+        // `node_modules/react-router-dom/` and `node_modules/react-dom/` both
+        // contain the string `react`, and a bare `react` test would swallow
+        // them into vendor and silently collapse three chunks into one.
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return
+          if (/[\\/]node_modules[\\/]react-router-dom[\\/]/.test(id)) return 'router'
+          if (/[\\/]node_modules[\\/]@tanstack[\\/]react-query[\\/]/.test(id)) return 'query'
+          if (/[\\/]node_modules[\\/]react-dom[\\/]/.test(id)) return 'vendor'
+          if (/[\\/]node_modules[\\/]react[\\/]/.test(id)) return 'vendor'
         },
       },
     },


### PR DESCRIPTION
Unblocks #23 (the vite/@vitejs/plugin-react/vitest bump), whose `Frontend Build` fails with:

```
TypeError: manualChunks is not a function
```

Vite 8 builds with **rolldown**, which accepts only the function form of `manualChunks`. Rollup accepts both, so this change is correct before and after the upgrade and can land on its own.

Order of the tests is load-bearing: `node_modules/react-router-dom/` and `node_modules/react-dom/` both contain the string `react`, so a bare `react` test placed first would swallow both into `vendor` and silently collapse three chunks into one. Longest prefix is tested first.

Verified locally against the *current* vite — identical chunking to the object form:

```
dist/assets/query-BNuyC9D4.js    26.79 kB
dist/assets/router-CvvqL0Ko.js   37.70 kB
dist/assets/vendor-DDKPOPFy.js  141.81 kB
```